### PR TITLE
fix: Throw TimeoutError when overall deadline is exceeded

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/robust_operation.js
+++ b/robust_operation.js
@@ -317,7 +317,9 @@ export class RobustOperation {
         const elapsed = monotonicNowMs() - startMono;
         const budgetLeft = overallDeadlineMs ? Math.max(0, overallDeadlineMs - elapsed) : Infinity;
         if (overallDeadlineMs && budgetLeft <= 0) {
-          throw lastError instanceof Error ? lastError : new TimeoutError('Overall deadline exceeded');
+          // Always throw a timeout error to make it clear the deadline was the cause.
+          // The last actual error is still available via the `onError` hook.
+          throw new TimeoutError('Overall deadline exceeded');
         }
 
         attemptsPerformed = attempt + 1;


### PR DESCRIPTION
When an `overallDeadlineMs` is configured and it expires between two retry attempts, the `run()` method was incorrectly throwing the error from the previous failed attempt instead of a `TimeoutError`.

This is misleading because the actual reason for the operation's termination is the overall deadline being exceeded, not the error from the last attempt.

This commit changes the logic to always throw a `TimeoutError` with the message "Overall deadline exceeded" when the overall deadline is met. This ensures the error correctly reflects the reason for termination.