### PR TITLE
fix: Handle past dates in Retry-After header

### DIFF
--- a/robust_operation.js
+++ b/robust_operation.js
@@ -612,7 +612,7 @@ function parseRetryAfterValue(value, nowMs) {
   const t = Date.parse(v);
   if (Number.isNaN(t)) return null;
   const delta = t - nowMs;
-  return delta >= 0 ? delta : null;
+  return delta >= 0 ? delta : 0;
 }
 
 /**

--- a/robust_operation.test.js
+++ b/robust_operation.test.js
@@ -1,0 +1,33 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { RobustOperation } from './robust_operation.js';
+
+test('should use a zero delay for a Retry-After date in the past', async () => {
+  let capturedDelay = -1;
+  const pastDate = new Date(Date.now() - 10000).toUTCString();
+
+  const ro = new RobustOperation({
+    retries: 1,
+    minDelay: 0, // Ensure no artificial minimum delay interferes
+    backoffBase: 5000, // Make the default backoff high to contrast with 0
+    onError: (err, attempt, willRetry, ctx) => {
+      if (willRetry) {
+        capturedDelay = ctx.nextDelayMs;
+      }
+    },
+  });
+
+  const errorToThrow = new Error('Throttled');
+  errorToThrow.status = 429;
+  errorToThrow.headers = { 'Retry-After': pastDate };
+
+  try {
+    await ro.run(async () => {
+      throw errorToThrow;
+    });
+  } catch (e) {
+    // Expected to fail after retries
+  }
+
+  assert.strictEqual(capturedDelay, 0, 'The retry delay for a past date should be 0ms');
+});


### PR DESCRIPTION
The `parseRetryAfterValue` function incorrectly handled `Retry-After` headers with a date in the past. It returned `null`, causing the operation to fall back to the default backoff strategy instead of retrying immediately.

According to RFC 7231, a `Retry-After` date in the past indicates the client can retry immediately.

This commit changes the function to return a delay of `0` when the `Retry-After` date is in the past, aligning with the specification. A new test case has been added to verify this behavior.