### PR TITLE
fix(jitter): Prevent getting stuck at zero

### DIFF
--- a/robust_operation.js
+++ b/robust_operation.js
@@ -94,7 +94,11 @@ export function createDecorrelatedJitter(base, max, random = Math.random) {
   let sleep = Math.max(0, base);
   return () => {
     const lo = Math.max(0, base);
-    const hi = Math.max(lo, sleep * 3);
+    let hi = Math.max(lo, sleep * 3);
+    // If base and sleep are 0, hi will be 0. Widen the range to max to unstick the generator.
+    if (hi <= lo) {
+      hi = max;
+    }
     const u = Math.max(0, Math.min(1, Number(random()) || 0));
     const next = lo + u * (hi - lo);
     sleep = Math.min(max, next);

--- a/robust_operation.test.js
+++ b/robust_operation.test.js
@@ -1,6 +1,23 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { RobustOperation } from './robust_operation.js';
+import { RobustOperation, createDecorrelatedJitter } from './robust_operation.js';
+
+test('createDecorrelatedJitter should not get stuck at zero', () => {
+  const maxDelay = 100;
+  const jitter = createDecorrelatedJitter(0, maxDelay, () => 0.5); // Use a predictable random generator
+
+  const results = Array.from({ length: 5 }, () => jitter());
+
+  // With a base of 0, the first result will be 0.
+  // The bug is that all subsequent results are also 0.
+  // The fix should ensure that subsequent results can be > 0.
+  const sum = results.reduce((a, b) => a + b, 0);
+
+  assert.ok(sum > 0, 'The jitter function should produce non-zero delays eventually');
+  results.forEach(r => {
+    assert.ok(r >= 0 && r <= maxDelay, 'Each result should be within the [0, max] range');
+  });
+});
 
 test('should use a zero delay for a Retry-After date in the past', async () => {
   let capturedDelay = -1;


### PR DESCRIPTION
The `createDecorrelatedJitter` function would get stuck returning 0 if the base delay was initialized to 0. This was because the internal `sleep` state, used for calculating the upper bound of the random delay, would also be 0, resulting in a zero-width range for the jitter calculation.

This commit fixes the issue by checking if the calculated upper bound (`hi`) is less than or equal to the lower bound (`lo`). If it is, `hi` is set to the `max` value, which "unsticks" the generator and allows it to produce a non-zero, jittered delay as intended.

A new test case has been added to verify that the generator no longer gets stuck at zero.